### PR TITLE
fix: デザイン調整 (Issue #17) + HoverPreview 連鎖バグ修正

### DIFF
--- a/e2e/home-page.e2e.ts
+++ b/e2e/home-page.e2e.ts
@@ -7,22 +7,16 @@ test.describe('/ (ホームページ)', () => {
 
   // --- hero セクション ---
 
-  test('hero セクションが表示される', async ({ page }) => {
-    const hero = page.locator('.home-hero__prompt')
-    await expect(hero).toBeVisible()
-    await expect(hero).toContainText('~/blog $ ls')
-  })
-
-  test('h1.home-title に "きせのブログ" が表示される', async ({ page }) => {
+  test('h1.home-title に "blog" が表示される', async ({ page }) => {
     const h1 = page.locator('h1.home-title')
     await expect(h1).toBeVisible()
-    await expect(h1).toContainText('きせのブログ')
+    await expect(h1).toContainText('blog')
   })
 
-  test('p.home-subtitle に "型理論" が含まれる', async ({ page }) => {
+  test('p.home-subtitle に "理論 CS 学び直し" が含まれる', async ({ page }) => {
     const subtitle = page.locator('p.home-subtitle')
     await expect(subtitle).toBeVisible()
-    await expect(subtitle).toContainText('型理論')
+    await expect(subtitle).toContainText('理論 CS 学び直し')
   })
 
   // --- 2カラムグリッド ---

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:all": "vitest run && playwright test"
   },
   "dependencies": {
     "@astrojs/react": "^4.0.0",

--- a/src/components/HeaderSearch.module.css
+++ b/src/components/HeaderSearch.module.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   position: relative;
+  margin-left: auto;
 }
 
 .input {

--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -106,26 +106,26 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
   // popup を閉じる: 対象 id と全子孫を削除。タイマーも同時にキャンセルする
   const closePopup = useCallback(
     (id: number) => {
-      setPopups((prev) => {
-        const toRemove = new Set<number>()
-        const queue = [id]
-        while (queue.length > 0) {
-          const cur = queue.shift()!
-          toRemove.add(cur)
-          for (const p of prev) {
-            if (p.parentId === cur) queue.push(p.id)
-          }
+      const toRemove = new Set<number>()
+      const queue = [id]
+      while (queue.length > 0) {
+        const cur = queue.shift()!
+        toRemove.add(cur)
+        for (const p of popupsRef.current) {
+          if (p.parentId === cur) queue.push(p.id)
         }
-        // 削除対象の全タイマーをキャンセル
-        toRemove.forEach((rid) => {
-          const t = timersRef.current.get(rid)
-          if (t !== undefined) {
-            clearTimeout(t)
-            timersRef.current.delete(rid)
-          }
-        })
-        return prev.filter((p) => !toRemove.has(p.id))
+      }
+      // 削除対象の全タイマーをキャンセル
+      toRemove.forEach((rid) => {
+        const t = timersRef.current.get(rid)
+        if (t !== undefined) {
+          clearTimeout(t)
+          timersRef.current.delete(rid)
+        }
       })
+      // popupsRef を同期更新してから setPopups (描画間の重複チェックを正確にするため)
+      popupsRef.current = popupsRef.current.filter((p) => !toRemove.has(p.id))
+      setPopups(popupsRef.current)
     },
     [],
   )
@@ -134,6 +134,7 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
   const closeAll = useCallback(() => {
     timersRef.current.forEach((t) => clearTimeout(t))
     timersRef.current.clear()
+    popupsRef.current = []
     setPopups([])
   }, [])
 
@@ -195,10 +196,12 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
         getAncestorIds(parentPopupId, popupsRef.current).forEach((aid) => cancelTimer(aid))
       }
 
-      setPopups((prev) => [
-        ...prev,
+      // popupsRef を同期更新してから setPopups (描画間の重複チェックを正確にするため)
+      popupsRef.current = [
+        ...popupsRef.current,
         { id, parentId: parentPopupId, title, html, left, top, anchorTop, zIndex, isLocal },
-      ])
+      ]
+      setPopups(popupsRef.current)
       linkPopupMapRef.current.set(linkEl, id)
 
       return id

--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -49,6 +49,9 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
   // タッチ長押し用
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const longPressActiveRef = useRef(false)
+  // popup が DOM に追加された直後の mouseenter カスケードを抑制するフラグ
+  // (新要素がカーソル下に現れるとブラウザが mouseenter を再発火し、連鎖増殖が起きるため)
+  const suppressNewPopupRef = useRef(false)
 
   // portal コンテナの作成・削除
   useEffect(() => {
@@ -204,6 +207,11 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
       setPopups(popupsRef.current)
       linkPopupMapRef.current.set(linkEl, id)
 
+      // popup が DOM に追加された直後、カーソル下に現れた新要素への mouseenter を抑制する
+      // (ブラウザは新要素出現時に mouseenter を再発火するため、連鎖増殖が起きる)
+      suppressNewPopupRef.current = true
+      setTimeout(() => { suppressNewPopupRef.current = false }, 0)
+
       return id
     },
     [cancelTimer, getAncestorIds],
@@ -234,6 +242,8 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
 
     // リンクに対して popup を表示する (重複チェック込み)
     function tryShowLink(linkEl: HTMLElement) {
+      // popup 生成直後のカスケード抑制 (既存 popup のタイマーキャンセルは行う)
+      if (suppressNewPopupRef.current) return
       const existingId = linkPopupMapRef.current.get(linkEl)
       if (existingId !== undefined) {
         const popupStillExists = popupsRef.current.some((p) => p.id === existingId)

--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -242,13 +242,11 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
 
     // リンクに対して popup を表示する (重複チェック込み)
     function tryShowLink(linkEl: HTMLElement) {
-      // popup 生成直後のカスケード抑制 (既存 popup のタイマーキャンセルは行う)
-      if (suppressNewPopupRef.current) return
       const existingId = linkPopupMapRef.current.get(linkEl)
       if (existingId !== undefined) {
         const popupStillExists = popupsRef.current.some((p) => p.id === existingId)
         if (popupStillExists) {
-          // popup が生きている: タイマーをキャンセルするだけ
+          // popup が生きている: タイマーをキャンセルするだけ (抑制中でも閉じさせない)
           cancelTimer(existingId)
           getAncestorIds(existingId, popupsRef.current).forEach((aid) => cancelTimer(aid))
           return
@@ -256,6 +254,8 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
         // popup は既に閉じている: 古いマッピングを削除して新規表示へ
         linkPopupMapRef.current.delete(linkEl)
       }
+      // popup 生成直後のカスケード抑制: 既存タイマーキャンセルは行うが新規 popup は作らない
+      if (suppressNewPopupRef.current) return
       showPopupForLink(linkEl, getParentPopupId(linkEl))
     }
 

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -15,9 +15,8 @@ const { title, siteTitle = 'blog', activePage, pagefindIgnore } = Astro.props
 const base = import.meta.env.BASE_URL.replace(/\/$/, '')
 
 const navItems = [
-  { label: 'home',   href: `${base}/`,        key: 'home'   },
-  { label: 'posts',  href: `${base}/posts`,    key: 'post'   },
-  { label: 'series', href: `${base}/series`,   key: 'series' },
+  { label: 'home',  href: `${base}/`,      key: 'home' },
+  { label: 'posts', href: `${base}/posts`, key: 'post' },
 ] as const
 ---
 

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -11,13 +11,12 @@ interface Props {
   pagefindIgnore?: boolean
 }
 
-const { title, siteTitle = 'kise.dev', activePage, pagefindIgnore } = Astro.props
+const { title, siteTitle = 'blog', activePage, pagefindIgnore } = Astro.props
 const base = import.meta.env.BASE_URL.replace(/\/$/, '')
 
 const navItems = [
   { label: 'home',   href: `${base}/`,        key: 'home'   },
   { label: 'posts',  href: `${base}/posts`,    key: 'post'   },
-  { label: 'defs',   href: `${base}/defs`,     key: 'def'    },
   { label: 'series', href: `${base}/series`,   key: 'series' },
 ] as const
 ---
@@ -64,8 +63,7 @@ const navItems = [
       <header class="site-header">
         <div class="site-header__inner">
           <a class="site-logo" href={`${base}/`}>
-            <span class="site-logo__prompt">$</span>
-            <span>{siteTitle}</span>
+            {siteTitle}
           </a>
           <nav class="site-nav">
             {navItems.map((item) => (

--- a/src/components/__tests__/HoverPreview.test.tsx
+++ b/src/components/__tests__/HoverPreview.test.tsx
@@ -285,6 +285,8 @@ describe('HoverPreview', () => {
       await act(async () => {
         fireEvent.mouseEnter(link)
         await Promise.resolve()
+        // popup 生成直後の mouseenter 抑制 (setTimeout 0ms) をクリアする
+        vi.advanceTimersByTime(1)
       })
 
       // 親 popup 内に concept-link を追加
@@ -360,6 +362,8 @@ describe('HoverPreview', () => {
       await act(async () => {
         fireEvent.mouseEnter(link)
         await Promise.resolve()
+        // popup 生成直後の mouseenter 抑制 (setTimeout 0ms) をクリアする
+        vi.advanceTimersByTime(1)
       })
 
       const parentPopup = document.body.querySelector('.hover-preview') as HTMLElement

--- a/src/pages/defs/[id].astro
+++ b/src/pages/defs/[id].astro
@@ -72,20 +72,20 @@ const displayAliases = def.data.aliases.filter((a) => a !== def.id)
 
     <header class="def-header">
       <div class="def-header__type">定義 / DEFINITION</div>
-      <h1 class="def-title">{def.data.title}</h1>
-      <div class="def-meta">
+      <div class="def-title-row">
+        <h1 class="def-title">{def.data.title}</h1>
         <span class="def-id-badge">{def.id}</span>
         {displayAliases.length > 0 && (
           <span class="def-aliases">別名: {displayAliases.join(', ')}</span>
         )}
-        {def.data.tags.length > 0 && (
-          <div class="def-tags">
-            {def.data.tags.map((tag) => (
-              <TagBadge tag={tag} href={`${base}/tags/${tag}`} />
-            ))}
-          </div>
-        )}
       </div>
+      {def.data.tags.length > 0 && (
+        <div class="def-tags">
+          {def.data.tags.map((tag) => (
+            <TagBadge tag={tag} href={`${base}/tags/${tag}`} />
+          ))}
+        </div>
+      )}
     </header>
 
     <!-- Pagefind フィルタ用 (1 タグ 1 span) -->
@@ -125,15 +125,15 @@ const displayAliases = def.data.aliases.filter((a) => a !== def.id)
     text-transform: uppercase;
     margin-bottom: 0.4rem;
   }
+  .def-title-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+  }
   .def-title {
     font-size: 1.55rem;
-    margin-bottom: 0.6rem;
-  }
-  .def-meta {
-    display: flex;
-    align-items: center;
-    gap: 0.7rem;
-    flex-wrap: wrap;
   }
   .def-id-badge {
     font-family: var(--font-code);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,12 +48,11 @@ const allTags = [...new Set([
 ])]
 ---
 
-<Layout title="きせのブログ" activePage="home">
+<Layout title="blog (仮)" activePage="home">
   <div class="container" data-pagefind-ignore>
     <div class="home-hero">
-      <div class="home-hero__prompt">~/blog $ ls</div>
-      <h1 class="home-title">きせのブログ</h1>
-      <p class="home-subtitle">型理論 · 論理学 · 数学 · プログラミング言語理論</p>
+      <h1 class="home-title">blog (仮)</h1>
+      <p class="home-subtitle">理論 CS 学び直し</p>
     </div>
 
     <div class="home-grid">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -154,7 +154,6 @@ a:hover { color: var(--link-h); }
   letter-spacing: 0.03em;
 }
 .site-logo:hover { color: var(--text); }
-.site-logo__prompt { color: var(--accent); font-size: 1.05rem; }
 .site-nav { display: flex; align-items: center; gap: 1.5rem; }
 .site-nav a {
   font-family: var(--font-ui);
@@ -340,14 +339,6 @@ a:hover { color: var(--link-h); }
 
 /* ── HOME HERO ─────────────────────────────────── */
 .home-hero { margin-bottom: 2.8rem; padding: 2.4rem 0 2rem; }
-.home-hero__prompt {
-  font-family: var(--font-ui);
-  font-size: 0.82rem;
-  color: var(--accent);
-  margin-bottom: 0.6rem;
-  letter-spacing: 0.05em;
-}
-.home-hero__prompt::before { content: '› '; }
 .home-title { font-family: var(--font-ui); font-size: 2rem; letter-spacing: 0.02em; color: var(--text); margin-bottom: 0.4rem; }
 .home-subtitle { font-family: var(--font-body); color: var(--text-muted); font-size: 0.9rem; }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -141,7 +141,7 @@ a:hover { color: var(--link-h); }
   height: 52px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 1.5rem;
 }
 .site-logo {
   font-family: var(--font-ui);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -376,6 +376,8 @@ a:hover { color: var(--link-h); }
 /* post-card 追加フィールド */
 .post-card__tags { display: flex; gap: 0.3rem; flex-wrap: wrap; }
 .post-card__series { font-size: 0.72rem; color: var(--text-faint); font-family: var(--font-ui); margin-top: 0.3rem; }
+/* カード内タグは hover で見た目を変えない (クリックしても記事に飛ぶだけなので誤解を招かないよう) */
+.post-card .tag:hover { opacity: 1; }
 
 /* ── VIEW ALL LINK ──────────────────────────────── */
 .view-all {


### PR DESCRIPTION
## Summary

- ロゴを `$ kise.dev` → `blog` に変更、header nav から `defs` を削除
- home hero の prompt 行 (`~/blog $ ls`) を削除、タイトル・subtitle を更新
- 検索欄拡張時に nav がズレる問題を修正 (`space-between` → `gap` + `margin-left: auto`)
- defs ページの英語名・別名をタイトル右横に移動
- post-card 内タグの hover 視覚変化を抑制（クリックしても記事に飛ぶだけなので誤解を招かないよう）
- `test:all` スクリプト追加 (`vitest run && playwright test`)
- **HoverPreview のポップアップ連鎖増殖バグを修正**: `popupsRef.current` が React 再描画前に古い値を参照するため、mouseenter 連続発火時に同一リンクから何十ものポップアップが生成される問題を修正

## Test plan

- [x] `pnpm astro check` — 0 errors
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 149 passed
- [x] `pnpm test:e2e` — 121 passed (HoverPreview flaky も解消)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)