### PR TITLE
fix: hover preview 内の同一 term による連鎖増殖を修正 (Issue #32)

### DIFF
--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -23,6 +23,8 @@ interface PopupState {
   anchorTop: number // link.top (viewport 下端超え時の反転計算に使用)
   zIndex: number
   isLocal: boolean  // ローカル定義の場合 true → MathJax を再実行しない
+  term: string | undefined      // global concept-link の data-term (重複チェック用)
+  localId: string | undefined   // local concept-link の data-local-id (重複チェック用)
 }
 
 let _popupIdCounter = 0
@@ -193,6 +195,19 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
       // z-index: ベース 9000 + popup 生成順の id (hover 回数に応じて増加)
       const zIndex = 9000 + id
 
+      // 祖先 popup に同一 term / localId がある場合はスキップ (Issue #32: 自己参照 cascade 防止)
+      if (parentPopupId !== null) {
+        const ancestorAndParentIds = [parentPopupId, ...getAncestorIds(parentPopupId, popupsRef.current)]
+        const hasDuplicate = ancestorAndParentIds.some((aid) => {
+          const ancestor = popupsRef.current.find((p) => p.id === aid)
+          if (!ancestor) return false
+          if (term !== undefined) return ancestor.term === term
+          if (localId !== undefined) return ancestor.localId === localId
+          return false
+        })
+        if (hasDuplicate) return null
+      }
+
       // 親とその祖先のタイマーをキャンセル
       if (parentPopupId !== null) {
         cancelTimer(parentPopupId)
@@ -202,7 +217,7 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
       // popupsRef を同期更新してから setPopups (描画間の重複チェックを正確にするため)
       popupsRef.current = [
         ...popupsRef.current,
-        { id, parentId: parentPopupId, title, html, left, top, anchorTop, zIndex, isLocal },
+        { id, parentId: parentPopupId, title, html, left, top, anchorTop, zIndex, isLocal, term, localId },
       ]
       setPopups(popupsRef.current)
       linkPopupMapRef.current.set(linkEl, id)

--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -184,17 +184,6 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
         return null
       }
 
-      const rect = linkEl.getBoundingClientRect()
-      const popupWidth = 330
-      const viewportPadding = 8
-      const maxLeft = Math.max(viewportPadding, window.innerWidth - popupWidth - viewportPadding)
-      const left = Math.max(viewportPadding, Math.min(rect.left, maxLeft))
-      const top = rect.bottom + 8
-      const anchorTop = rect.top
-      const id = nextPopupId()
-      // z-index: ベース 9000 + popup 生成順の id (hover 回数に応じて増加)
-      const zIndex = 9000 + id
-
       // 祖先 popup に同一 term / localId がある場合はスキップ (Issue #32: 自己参照 cascade 防止)
       if (parentPopupId !== null) {
         const ancestorAndParentIds = [parentPopupId, ...getAncestorIds(parentPopupId, popupsRef.current)]
@@ -207,6 +196,17 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
         })
         if (hasDuplicate) return null
       }
+
+      const rect = linkEl.getBoundingClientRect()
+      const popupWidth = 330
+      const viewportPadding = 8
+      const maxLeft = Math.max(viewportPadding, window.innerWidth - popupWidth - viewportPadding)
+      const left = Math.max(viewportPadding, Math.min(rect.left, maxLeft))
+      const top = rect.bottom + 8
+      const anchorTop = rect.top
+      const id = nextPopupId()
+      // z-index: ベース 9000 + popup 生成順の id (hover 回数に応じて増加)
+      const zIndex = 9000 + id
 
       // 親とその祖先のタイマーをキャンセル
       if (parentPopupId !== null) {

--- a/src/components/__tests__/HoverPreview.test.tsx
+++ b/src/components/__tests__/HoverPreview.test.tsx
@@ -448,6 +448,53 @@ describe('HoverPreview', () => {
       expect(document.body.querySelector('.hover-preview')).not.toBeNull()
     })
 
+    it('popup 内の同一 term の concept-link に mouseenter しても popup が増えない (Issue #32)', async () => {
+      await renderAndSettle()
+      const link = addGlobalConceptLink('poset')
+
+      await act(async () => {
+        fireEvent.mouseEnter(link)
+        await Promise.resolve()
+        // popup 生成直後の mouseenter 抑制 (setTimeout 0ms) をクリアする
+        vi.advanceTimersByTime(1)
+      })
+
+      const parentPopup = document.body.querySelector('.hover-preview') as HTMLElement
+      expect(parentPopup).not.toBeNull()
+      expect(document.body.querySelectorAll('.hover-preview').length).toBe(1)
+
+      // 親 popup 内に同一 term (poset) の自己参照 concept-link を追加
+      const selfRefLink = document.createElement('a')
+      selfRefLink.className = 'concept-link'
+      selfRefLink.dataset.term = 'poset'
+      selfRefLink.href = '/defs/poset'
+      selfRefLink.textContent = 'poset'
+      selfRefLink.getBoundingClientRect = () => ({
+        left: 120,
+        right: 220,
+        top: 200,
+        bottom: 220,
+        width: 100,
+        height: 20,
+        x: 120,
+        y: 200,
+        toJSON: () => ({}),
+      })
+      parentPopup.querySelector('.hover-preview__body')?.appendChild(selfRefLink)
+
+      // 同一 term の self-reference link に mouseenter × 3 (cascade を再現)
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          fireEvent.mouseEnter(selfRefLink)
+          await Promise.resolve()
+          vi.advanceTimersByTime(1)
+        })
+      }
+
+      // popup は増えない (同一 term なので子 popup を開かない)
+      expect(document.body.querySelectorAll('.hover-preview').length).toBe(1)
+    })
+
     it('子 popup から mouseleave すると子のみ閉じる (親は残る)', async () => {
       await renderAndSettle()
       const link = addGlobalConceptLink('poset')

--- a/tasks/done/TASK-014-hover-preview-duplicate-fix.md
+++ b/tasks/done/TASK-014-hover-preview-duplicate-fix.md
@@ -1,0 +1,41 @@
+# TASK-014: hover preview 重複表示バグ修正 (Issue #32)
+
+## 参照仕様
+
+- docs/features/hover-preview.md
+- GitHub Issue #32
+
+## 問題
+
+popup の body HTML に自己参照 concept-link (同一 term) が含まれると、
+popup が DOM に追加された直後にブラウザがその concept-link に `mouseenter` を再発火し、
+同じ popup が何個も積み重なる。
+
+**根因**: `suppressNewPopupRef` の setTimeout(0) は React の再描画よりも先に
+フラグをリセットしてしまう場合がある。結果として popup 内の concept-link への
+mouseenter が抑制されずに連鎖増殖する。
+
+**修正方針**: popup を新規作成する前に、祖先 popup チェーンに同じ term / localId
+がすでに存在するかを確認する。存在すれば新規作成をスキップする。
+
+実装変更:
+1. `PopupState` に `term: string | undefined` と `localId: string | undefined` を追加
+2. `showPopupForLink` で祖先に同じ term/localId があればスキップ
+3. (オプション) `suppressNewPopupRef` 機構は維持しつつ重複チェックを主防衛とする
+
+## チェックリスト
+
+- [x] 落ちるテストを書く: popup 内の同一 term concept-link への mouseenter で popup が重複しない
+- [x] `PopupState` に `term` / `localId` フィールドを追加
+- [x] `showPopupForLink` に祖先チェックを追加
+- [x] テストがパスすることを確認
+- [x] 既存テストが全てパスすることを確認 (`pnpm test`)
+
+## 完了条件
+
+- [x] `pnpm test` が全てパス
+- [x] Issue #32 の再現シナリオ (自己参照 term) が 1 つの popup のみを表示する
+
+## 作業ログ
+
+- 2026-05-01: 作業開始


### PR DESCRIPTION
## Summary

- `PopupState` に `term` / `localId` フィールドを追加し、各 popup が表示中の term/localId を保持するようにした
- `showPopupForLink` で新規 popup 作成前に祖先チェーンを確認し、同一 term/localId が存在する場合はスキップする
- 自己参照定義 (定義本文に同じ term への concept-link を含む) でも popup が重複せず 1 つだけ表示される

## Fixes

Closes #32

## Test plan

- [x] `pnpm test` — 168 tests passed (新規テスト: "popup 内の同一 term の concept-link に mouseenter しても popup が増えない (Issue #32)")
- [x] `pnpm astro check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)