### PR TITLE
feat: [[term]] はタイトルのみ、![[term]] で英語表示をオプトイン (issue #33)

### DIFF
--- a/docs/features/concept-link.md
+++ b/docs/features/concept-link.md
@@ -250,7 +250,7 @@ remarkParse
 | alias 重複 | アルファベット順で先勝ち + console.warn |
 | `[[term]]` 未解決 (開発) | `concept-link--unresolved` クラス付きリンク |
 | `[[term]]` 未解決 (本番) | プレーンテキスト + console.warn |
-| `[[#anchor]]` | スキップ (local-definition が処理) |
+| `[[#anchor]]` | `localIds` に応じて local link / unresolved / plain text を出し分け |
 | term にスペースを含む | `[[直積 集合]]` → マッチ対象 (正規表現で許容) |
 
 ## 未決事項

--- a/docs/features/concept-link.md
+++ b/docs/features/concept-link.md
@@ -89,16 +89,17 @@ updateConfig({
 
 ```markdown
 [[半順序集合]] において [[上界]] が存在するとは限らない。
+![[半順序集合]] において ...  ← 英語をかっこ書きで表示したい場合
 ```
 
-`[[term]]` はインライン記法。remark の `text` ノードを walk して正規表現でパースする。
+`[[term]]` / `![[term]]` はインライン記法。remark の `text` ノードを walk して正規表現でパースする。
 
 ```ts
 // src/lib/remark/parse-concept-links.ts (backlink-graph と共有)
-// 現状: [[term]] のみ対応
-export const CONCEPT_LINK_REGEX = /\[\[([^\]]+)\]\]/g
+// ![[term]] と [[term]] の両方にマッチする
+export const CONCEPT_LINK_REGEX = /!?\[\[([^\]]+)\]\]/g
 export function parseConceptLinks(text: string): string[]
-// 将来予定: [[term|display]] 対応時は /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g に変更
+// 将来予定: [[term|display]] 対応時は正規表現を変更
 ```
 
 ### `[[term|display]]` 記法 (将来予定 — 未実装)
@@ -119,7 +120,13 @@ export function parseConceptLinks(text: string): string[]
 
 ### 出力
 
-**解決成功時:**
+**`[[term]]` 解決成功時 (英語なし・デフォルト):**
+
+```html
+<a class="concept-link" data-term="poset" href="/defs/poset">半順序集合</a>
+```
+
+**`![[term]]` 解決成功時 (英語あり):**
 
 ```html
 <a class="concept-link" data-term="poset" href="/defs/poset">半順序集合(partially ordered set)</a>
@@ -127,7 +134,11 @@ export function parseConceptLinks(text: string): string[]
 
 - `data-term`: canonical id (hover-preview がこれを使って preview-index.json を引く)
 - `href`: `{baseUrl}/defs/{canonicalId}`
-- リンクテキスト: `defMetaMap` が渡される通常ケースでは `{title}({english})`。`english` は frontmatter で required のため未設定/空文字は `scanDefsDirectory` が例外を投げてビルド停止し、`{title}` のみへのフォールバックは実際には発生しない。`defMetaMap` が省略された場合のみ元の `term` にフォールバックする。(将来予定: `display` があればそれを使う)
+- リンクテキスト:
+  - `[[term]]`: `title` のみ
+  - `![[term]]`: `title(english)` (`english` が空文字のときは `title` のみ)
+  - `defMetaMap` が省略・未登録の場合: 元の `term` にフォールバック
+  - (将来予定: `display` があればそれを使う)
 
 **解決失敗時 (開発環境):**
 
@@ -221,9 +232,12 @@ remarkParse
 
 | ケース | 期待出力 |
 |--------|---------|
-| 基本リンク | `<a class="concept-link" data-term="..." href="...">title(english)</a>` |
-| alias 経由で解決 | href は canonical id、テキストは title(english) |
-| `defMetaMap` なし、またはテスト用に `english` を空文字で注入 | テキストは title のみ |
+| `[[term]]` 基本リンク | `<a class="concept-link" data-term="..." href="...">title</a>` |
+| `[[term]]` alias 経由で解決 | href は canonical id、テキストは title のみ |
+| `![[term]]` 基本リンク | `<a class="concept-link" data-term="..." href="...">title(english)</a>` |
+| `![[term]]` alias 経由で解決 | href は canonical id、テキストは title(english) |
+| `![[term]]` english が空文字 | テキストは title のみ |
+| `defMetaMap` なし | テキストは term にフォールバック |
 | 解決失敗 (開発) | `<a class="concept-link concept-link--unresolved">` |
 | 解決失敗 (本番) | プレーンテキスト |
 | 1 ノードに複数 `[[term]]` | すべて変換される |

--- a/docs/features/concept-link.md
+++ b/docs/features/concept-link.md
@@ -104,7 +104,7 @@ export function parseConceptLinks(text: string): string[]
 
 ### `[[term|display]]` 記法 (将来予定 — 未実装)
 
-> **注意**: 現状の実装 (`parse-concept-links.ts`, `remark-concept-link.ts`) は `[[term]]` のみ対応。
+> **注意**: 現状の実装 (`parse-concept-links.ts`, `remark-concept-link.ts`) は `[[term]]` / `![[term]]` に対応。
 > `[[term|display]]` 記法は将来実装予定。
 
 表示テキストを指定する場合: `[[解決キー|表示テキスト]]`
@@ -241,7 +241,7 @@ remarkParse
 | 解決失敗 (開発) | `<a class="concept-link concept-link--unresolved">` |
 | 解決失敗 (本番) | プレーンテキスト |
 | 1 ノードに複数 `[[term]]` | すべて変換される |
-| `[[#anchor]]` | スキップ |
+| `[[#anchor]]` | `localIds` に応じて local link / unresolved / plain text を出し分ける |
 
 ## エッジケース
 

--- a/e2e/post-page.e2e.ts
+++ b/e2e/post-page.e2e.ts
@@ -42,7 +42,7 @@ test.describe('/posts/order-theory ページ', () => {
   test('[[半順序集合]] が .concept-link としてレンダリングされる', async ({ page }) => {
     const conceptLink = page.locator('.concept-link[data-term="poset"]').first()
     await expect(conceptLink).toBeVisible()
-    await expect(conceptLink).toHaveText('半順序集合(partially ordered set)')
+    await expect(conceptLink).toHaveText('半順序集合')
   })
 
   test('::embed[poset] で .definition-block が1つ以上表示される', async ({ page }) => {

--- a/src/lib/remark/parse-concept-links.test.ts
+++ b/src/lib/remark/parse-concept-links.test.ts
@@ -31,6 +31,16 @@ describe('parseConceptLinks', () => {
     const result = parseConceptLinks('[[直積 集合]] について。')
     expect(result).toEqual(['直積 集合'])
   })
+
+  it('![[term]] も term を抽出する (! プレフィックスは除く)', () => {
+    const result = parseConceptLinks('![[poset]] について説明する。')
+    expect(result).toEqual(['poset'])
+  })
+
+  it('[[term]] と ![[term]] が混在する場合、両方の term を抽出する', () => {
+    const result = parseConceptLinks('[[半順序集合]] と ![[上界]] の話。')
+    expect(result).toEqual(['半順序集合', '上界'])
+  })
 })
 
 describe('parseEmbeds', () => {

--- a/src/lib/remark/parse-concept-links.ts
+++ b/src/lib/remark/parse-concept-links.ts
@@ -1,4 +1,4 @@
-// ![[term]] と [[term]] の両方にマッチする。グループ1: optional '!', グループ2: term
+// ![[term]] と [[term]] の両方にマッチする。グループ1: term（先頭の '!' はキャプチャしない）
 export const CONCEPT_LINK_REGEX = /!?\[\[([^\]]+)\]\]/g
 
 /**

--- a/src/lib/remark/parse-concept-links.ts
+++ b/src/lib/remark/parse-concept-links.ts
@@ -1,7 +1,8 @@
-export const CONCEPT_LINK_REGEX = /\[\[([^\]]+)\]\]/g
+// ![[term]] と [[term]] の両方にマッチする。グループ1: optional '!', グループ2: term
+export const CONCEPT_LINK_REGEX = /!?\[\[([^\]]+)\]\]/g
 
 /**
- * テキストから [[term]] 記法を抽出して term 文字列の配列を返す。
+ * テキストから [[term]] / ![[term]] 記法を抽出して term 文字列の配列を返す。
  * [[#id]] (先頭が #) は除外する。
  */
 export function parseConceptLinks(text: string): string[] {

--- a/src/lib/remark/remark-concept-link.test.ts
+++ b/src/lib/remark/remark-concept-link.test.ts
@@ -102,20 +102,22 @@ const processWithMeta = (md: string, aliasMap: AliasMap, defMetaMap: DefMetaMap,
     .toString()
 
 describe('remarkConceptLink defMetaMap 対応', () => {
-  it('defMetaMap あり: [[poset]] のリンクテキストが title(english) 形式になる', () => {
+  it('defMetaMap あり: [[poset]] のリンクテキストが title のみになる (英語なし)', () => {
     const aliasMap: AliasMap = { poset: 'poset' }
     const defMetaMap: DefMetaMap = { poset: { title: '半順序集合', english: 'partially ordered set' } }
     const html = processWithMeta('[[poset]] について説明する。', aliasMap, defMetaMap)
     expect(html).toContain('href="/defs/poset"')
-    expect(html).toContain('>半順序集合(partially ordered set)<')
+    expect(html).toContain('>半順序集合<')
+    expect(html).not.toContain('(partially ordered set)')
   })
 
-  it('defMetaMap あり alias 経由: [[半順序集合]] → canonical id で defMetaMap を引いてテキストが title(english) になる', () => {
+  it('defMetaMap あり alias 経由: [[半順序集合]] → canonical id で defMetaMap を引いてテキストが title のみになる', () => {
     const aliasMap: AliasMap = { '半順序集合': 'poset', poset: 'poset' }
     const defMetaMap: DefMetaMap = { poset: { title: '半順序集合', english: 'partially ordered set' } }
     const html = processWithMeta('[[半順序集合]] について説明する。', aliasMap, defMetaMap)
     expect(html).toContain('href="/defs/poset"')
-    expect(html).toContain('>半順序集合(partially ordered set)<')
+    expect(html).toContain('>半順序集合<')
+    expect(html).not.toContain('(partially ordered set)')
   })
 
   it('english が空文字の場合: リンクテキストが title のみになる', () => {
@@ -133,6 +135,38 @@ describe('remarkConceptLink defMetaMap 対応', () => {
     const html = processWithMeta('[[poset]] について説明する。', aliasMap, defMetaMap)
     expect(html).toContain('href="/defs/poset"')
     expect(html).toContain('>poset<')
+  })
+
+  it('![[term]]: defMetaMap あり のとき title(english) 形式になる', () => {
+    const aliasMap: AliasMap = { poset: 'poset' }
+    const defMetaMap: DefMetaMap = { poset: { title: '半順序集合', english: 'partially ordered set' } }
+    const html = processWithMeta('![[poset]] について説明する。', aliasMap, defMetaMap)
+    expect(html).toContain('href="/defs/poset"')
+    expect(html).toContain('>半順序集合(partially ordered set)<')
+  })
+
+  it('![[term]]: alias 経由でも title(english) 形式になる', () => {
+    const aliasMap: AliasMap = { '半順序集合': 'poset', poset: 'poset' }
+    const defMetaMap: DefMetaMap = { poset: { title: '半順序集合', english: 'partially ordered set' } }
+    const html = processWithMeta('![[半順序集合]] について説明する。', aliasMap, defMetaMap)
+    expect(html).toContain('href="/defs/poset"')
+    expect(html).toContain('>半順序集合(partially ordered set)<')
+  })
+
+  it('![[term]]: english が空文字の場合は title のみになる', () => {
+    const aliasMap: AliasMap = { poset: 'poset' }
+    const defMetaMap: DefMetaMap = { poset: { title: '半順序集合', english: '' } }
+    const html = processWithMeta('![[poset]] について説明する。', aliasMap, defMetaMap)
+    expect(html).toContain('>半順序集合<')
+    expect(html).not.toContain('()')
+  })
+
+  it('![[term]]: 解決失敗 (dev) のとき concept-link--unresolved が付く', () => {
+    const aliasMap: AliasMap = {}
+    const defMetaMap: DefMetaMap = {}
+    const html = processWithMeta('![[未知の概念]] について。', aliasMap, defMetaMap, false)
+    expect(html).toContain('concept-link--unresolved')
+    expect(html).toContain('>未知の概念<')
   })
 })
 

--- a/src/lib/remark/remark-concept-link.ts
+++ b/src/lib/remark/remark-concept-link.ts
@@ -11,7 +11,8 @@ interface ConceptLinkOptions {
   isProd?: boolean
 }
 
-const CONCEPT_LINK_REGEX_SOURCE = /\[\[([^\]]+)\]\]/.source
+// グループ1: optional '!', グループ2: term
+const CONCEPT_LINK_REGEX_SOURCE = /(!?)\[\[([^\]]+)\]\]/.source
 
 /**
  * hName/hProperties 付きのリンクノードを PhrasingContent として生成する。
@@ -82,11 +83,12 @@ function splitByConceptLinks(
   let match: RegExpExecArray | null
 
   while ((match = regex.exec(value)) !== null) {
-    const term = match[1]
+    const showEnglish = match[1] === '!'
+    const term = match[2]
     const start = match.index
     const end = regex.lastIndex
 
-    // [[#anchor]] の処理
+    // [[#anchor]] / ![[#anchor]] の処理
     if (term.startsWith('#')) {
       const id = term.slice(1)
       if (localIds === undefined) {
@@ -118,7 +120,7 @@ function splitByConceptLinks(
       continue
     }
 
-    // [[term]] が localIds に含まれる → local リンク (aliasMap より優先)
+    // [[term]] / ![[term]] が localIds に含まれる → local リンク (aliasMap より優先)
     if (localIds !== undefined && localIds.has(term)) {
       anyMatch = true
       if (start > lastIndex) {
@@ -144,7 +146,7 @@ function splitByConceptLinks(
       const href = `${baseUrl}defs/${canonicalId}`
       const meta = Object.hasOwn(defMetaMap, canonicalId) ? defMetaMap[canonicalId] : undefined
       const linkText = meta !== undefined
-        ? (meta.english !== '' ? `${meta.title}(${meta.english})` : meta.title)
+        ? (showEnglish && meta.english !== '' ? `${meta.title}(${meta.english})` : meta.title)
         : term
       parts.push(makeConceptLinkNode(href, ['concept-link'], linkText, canonicalId) as unknown as PhrasingContent)
     } else if (!isProd) {

--- a/tasks/done/TASK-015-concept-link-english-opt-in.md
+++ b/tasks/done/TASK-015-concept-link-english-opt-in.md
@@ -1,0 +1,39 @@
+# TASK-015: concept-link 英語表示のオプトイン化 (issue #33)
+
+## 参照仕様
+
+- docs/features/concept-link.md
+
+## 概要
+
+- 現状: `[[term]]` → `title(english)` 形式でリンクテキストを出力
+- 変更後:
+  - `[[term]]` → `title` のみ (英語なし)
+  - `![[term]]` → `title(english)` (英語をかっこ書きで表示)
+
+## チェックリスト
+
+### テスト (先に書く)
+
+- [x] `remark-concept-link.test.ts`: `[[term]]` で title のみになるテストを追加・既存テストを修正
+- [x] `remark-concept-link.test.ts`: `![[term]]` で `title(english)` になるテストを追加
+- [x] `parse-concept-links.test.ts`: `![[term]]` もパースされるテストを追加
+
+### 実装
+
+- [x] `src/lib/remark/parse-concept-links.ts`: `CONCEPT_LINK_REGEX` を `!?\[\[...\]\]` に更新
+- [x] `src/lib/remark/remark-concept-link.ts`: regex を `(!?)\[\[...\]\]` に変更、`!` 有無で英語表示を切り替え
+
+### 仕様更新
+
+- [x] `docs/features/concept-link.md`: `![[term]]` 記法と新しいデフォルト動作を反映
+
+## 完了条件
+
+- [x] `pnpm test` 全通過 (174 passed)
+- [x] `pnpm astro check` クリーン (0 errors)
+- [x] `pnpm build` 成功
+
+## 作業ログ
+
+- 2026-05-01: 作業開始・完了


### PR DESCRIPTION
## Summary

- `[[term]]` のデフォルト出力を `title(english)` → `title` のみに変更
- `![[term]]` 記法を新たに追加し、英語をかっこ書きで表示する場合に使う
- `english` が空文字のときは `![[term]]` でも `title` のみ

## 変更ファイル

- `src/lib/remark/parse-concept-links.ts` — regex を `!?\[\[...\]\]` に更新
- `src/lib/remark/remark-concept-link.ts` — `!` フラグで英語表示を切り替え
- テストファイル 2件、仕様ドキュメント更新

## Test plan

- [x] `pnpm test` 174 passed
- [x] `pnpm astro check` 0 errors
- [x] `pnpm build` 成功

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)