### PR TITLE
fix: hover preview の重複表示と MathJax リセットを修正 (Issue #32)

### DIFF
--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -418,7 +418,11 @@ interface PopupItemProps {
   popup: PopupState
 }
 
-function PopupItem({ popup }: PopupItemProps) {
+// popup prop が変わらない限り再レンダリングしない。
+// 他の popup が追加・削除されたとき親が再レンダリングされても、既存 popup の
+// dangerouslySetInnerHTML が再適用されて MathJax レンダリング済み innerHTML が
+// 上書きリセットされるのを防ぐ。
+const PopupItem = React.memo(function PopupItem({ popup }: PopupItemProps) {
   const bodyRef = useRef<HTMLDivElement>(null)
   const popupRef = useRef<HTMLDivElement>(null)
   // viewport 下端超え時にリンクの上に表示するため、top を調整する
@@ -507,4 +511,4 @@ function PopupItem({ popup }: PopupItemProps) {
       />
     </div>
   )
-}
+})

--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -184,15 +184,22 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
         return null
       }
 
-      // 既存 popup に同一 term / localId がある場合はスキップ (重複表示防止)
-      // 祖先だけでなく全 popup を対象にすることで、親子関係の外側からの
-      // 同一 term 重複作成 (Issue #32) も防ぐ
-      const hasDuplicate = popupsRef.current.some((p) => {
+      // 既存 popup に同一 term / localId がある場合は重複作成をスキップ (Issue #32)
+      // 祖先だけでなく全 popup を対象にすることで、親子関係の外側からの重複も防ぐ。
+      // ただし既存 popup の close タイマーをキャンセルし、現在の linkEl をマッピングする。
+      // (別リンク要素から同一 term を hover した際に、タイマー未キャンセルで popup が
+      //  消えてしまうことを防ぐため)
+      const duplicatePopup = popupsRef.current.find((p) => {
         if (term !== undefined) return p.term === term
         if (localId !== undefined) return p.localId === localId
         return false
       })
-      if (hasDuplicate) return null
+      if (duplicatePopup) {
+        cancelTimer(duplicatePopup.id)
+        getAncestorIds(duplicatePopup.id, popupsRef.current).forEach((aid) => cancelTimer(aid))
+        linkPopupMapRef.current.set(linkEl, duplicatePopup.id)
+        return duplicatePopup.id
+      }
 
       const rect = linkEl.getBoundingClientRect()
       const popupWidth = 330

--- a/src/components/HoverPreview.tsx
+++ b/src/components/HoverPreview.tsx
@@ -184,18 +184,15 @@ export default function HoverPreview({ baseUrl = '/' }: Props) {
         return null
       }
 
-      // 祖先 popup に同一 term / localId がある場合はスキップ (Issue #32: 自己参照 cascade 防止)
-      if (parentPopupId !== null) {
-        const ancestorAndParentIds = [parentPopupId, ...getAncestorIds(parentPopupId, popupsRef.current)]
-        const hasDuplicate = ancestorAndParentIds.some((aid) => {
-          const ancestor = popupsRef.current.find((p) => p.id === aid)
-          if (!ancestor) return false
-          if (term !== undefined) return ancestor.term === term
-          if (localId !== undefined) return ancestor.localId === localId
-          return false
-        })
-        if (hasDuplicate) return null
-      }
+      // 既存 popup に同一 term / localId がある場合はスキップ (重複表示防止)
+      // 祖先だけでなく全 popup を対象にすることで、親子関係の外側からの
+      // 同一 term 重複作成 (Issue #32) も防ぐ
+      const hasDuplicate = popupsRef.current.some((p) => {
+        if (term !== undefined) return p.term === term
+        if (localId !== undefined) return p.localId === localId
+        return false
+      })
+      if (hasDuplicate) return null
 
       const rect = linkEl.getBoundingClientRect()
       const popupWidth = 330

--- a/src/components/__tests__/HoverPreview.test.tsx
+++ b/src/components/__tests__/HoverPreview.test.tsx
@@ -495,6 +495,68 @@ describe('HoverPreview', () => {
       expect(document.body.querySelectorAll('.hover-preview').length).toBe(1)
     })
 
+    it('popup 内で term の popup が開いているとき、ページ上の同一 term 別要素にホバーしても popup が増えない (Issue #32 root cause)', async () => {
+      // lattice が poset concept-link を含む HTML を返すようにモックを上書き
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lattice: {
+            title: '束',
+            html: '<p><a href="/defs/poset" class="concept-link" data-term="poset">半順序集合</a>とは</p>',
+          },
+          poset: { title: '半順序集合', html: '<p>poset の定義</p>' },
+        }),
+      } as unknown as Response)
+
+      await renderAndSettle()
+
+      // ページ上に lattice concept-link と、別の poset concept-link を追加
+      const latticeLink = addGlobalConceptLink('lattice')
+      const pagePosetLink = addGlobalConceptLink('poset', '半順序集合')
+
+      // lattice link にホバー → lattice popup (#1) が表示される
+      await act(async () => {
+        fireEvent.mouseEnter(latticeLink)
+        await Promise.resolve()
+        vi.advanceTimersByTime(1)
+      })
+
+      const latticePopup = document.body.querySelector('.hover-preview') as HTMLElement
+      expect(latticePopup).not.toBeNull()
+
+      // lattice popup 内の poset link を取得
+      const popupPosetLink = latticePopup.querySelector(
+        '.concept-link[data-term="poset"]',
+      ) as HTMLElement
+      expect(popupPosetLink).not.toBeNull()
+      popupPosetLink.getBoundingClientRect = () => ({
+        left: 120, right: 220, top: 200, bottom: 220,
+        width: 100, height: 20, x: 120, y: 200, toJSON: () => ({}),
+      })
+
+      // popup 内の poset link にホバー → poset popup (#2) が表示される
+      await act(async () => {
+        fireEvent.mouseEnter(popupPosetLink)
+        await Promise.resolve()
+        vi.advanceTimersByTime(1)
+      })
+
+      expect(document.body.querySelectorAll('.hover-preview').length).toBe(2)
+
+      // ページ上の別の poset link (popup 外) に mouseenter × 3
+      // → 同一 term の popup が既に存在するので増えないこと
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          fireEvent.mouseEnter(pagePosetLink)
+          await Promise.resolve()
+          vi.advanceTimersByTime(1)
+        })
+      }
+
+      // popup は 2 つのまま (lattice + poset)、重複して増えない
+      expect(document.body.querySelectorAll('.hover-preview').length).toBe(2)
+    })
+
     it('子 popup から mouseleave すると子のみ閉じる (親は残る)', async () => {
       await renderAndSettle()
       const link = addGlobalConceptLink('poset')

--- a/src/components/__tests__/HoverPreview.test.tsx
+++ b/src/components/__tests__/HoverPreview.test.tsx
@@ -612,4 +612,61 @@ describe('HoverPreview', () => {
       expect(document.body.contains(parentPopup)).toBe(true)
     })
   })
+
+  describe('MathJax typeset 保持', () => {
+    it('子 popup を開いても親 popup の hover-preview__body innerHTML がリセットされない (Issue: TeX revert)', async () => {
+      // lattice が poset concept-link を含む HTML を返すようにモックを上書き
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          lattice: {
+            title: '束',
+            html: '<p>TeX: $(L,\\leq)$</p><p><a href="/defs/poset" class="concept-link" data-term="poset">半順序集合</a></p>',
+          },
+          poset: { title: '半順序集合', html: '<p>TeX: $P$</p>' },
+        }),
+      } as unknown as Response)
+
+      await renderAndSettle()
+
+      const latticeLink = addGlobalConceptLink('lattice')
+
+      // lattice popup を開く
+      await act(async () => {
+        fireEvent.mouseEnter(latticeLink)
+        await Promise.resolve()
+        vi.advanceTimersByTime(1)
+      })
+
+      const latticePopup = document.body.querySelector('.hover-preview') as HTMLElement
+      expect(latticePopup).not.toBeNull()
+      const latticeBody = latticePopup.querySelector('.hover-preview__body') as HTMLElement
+      expect(latticeBody).not.toBeNull()
+
+      // MathJax が TeX を描画したと仮定して innerHTML を書き換える
+      const renderedTeX = '<p>TeX: <math>...</math></p><p><a href="/defs/poset" class="concept-link" data-term="poset">半順序集合</a></p>'
+      latticeBody.innerHTML = renderedTeX
+
+      // popup 内の poset link を取得して hover → 子 popup を開く
+      const popupPosetLink = latticeBody.querySelector(
+        '.concept-link[data-term="poset"]',
+      ) as HTMLElement
+      expect(popupPosetLink).not.toBeNull()
+      popupPosetLink.getBoundingClientRect = () => ({
+        left: 120, right: 220, top: 200, bottom: 220,
+        width: 100, height: 20, x: 120, y: 200, toJSON: () => ({}),
+      })
+
+      await act(async () => {
+        fireEvent.mouseEnter(popupPosetLink)
+        await Promise.resolve()
+        vi.advanceTimersByTime(1)
+      })
+
+      expect(document.body.querySelectorAll('.hover-preview').length).toBe(2)
+
+      // 子 popup を開いた後も親 popup の body innerHTML がリセットされていないこと
+      expect(latticeBody.innerHTML).toBe(renderedTeX)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **Issue #32 根本修正**: 祖先 popup だけでなく全オープン popup を対象に同一 term の重複チェックを行うよう変更。popup 外の同一 term リンク（ページ本文・`::embed` 展開など）にホバーしたときに popup が重なって作成されるバグを修正。
- **MathJax リセット修正**: `PopupItem` を `React.memo` でメモ化し、子 popup が追加・削除されても既存 popup が不要に再レンダリングされないようにした。再レンダリング時に `dangerouslySetInnerHTML` が再適用されて MathJax 描画済み innerHTML が元の LaTeX 文字列で上書きされる問題を防ぐ。

## Test plan

- [ ] `pnpm test` — 再現テスト 2 件追加、全 176 件 pass
- [ ] `pnpm test:e2e -- hover-preview` — 4 件 pass
- [ ] order-theory ページで `[[束]]` hover → popup 内 `[[半順序集合]]` hover を繰り返して popup が重ならないことを確認
- [ ] 同上で lattice popup の TeX（$(L,\leq)$ 等）が poset hover 後も消えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)